### PR TITLE
Added support for english windows (forced utf-16)

### DIFF
--- a/translator.py
+++ b/translator.py
@@ -189,7 +189,7 @@ def export_to_excel():
         'Биполярное RZ:\t'+bipolarRZcode_for_excel(''.join(translate(name)[1][:4])),
         'NRZI:\t'+for_excel(nrzicode(''.join(translate(name)[1][:4])))
     ]
-    with open('codes.csv', 'w', encoding="utf-8") as file:
+    with open('codes.csv', 'w', encoding="utf-16") as file:
         for i in st_:
             file.write(i+'\n')
 

--- a/translator.py
+++ b/translator.py
@@ -189,7 +189,7 @@ def export_to_excel():
         'Биполярное RZ:\t'+bipolarRZcode_for_excel(''.join(translate(name)[1][:4])),
         'NRZI:\t'+for_excel(nrzicode(''.join(translate(name)[1][:4])))
     ]
-    with open('codes.csv', 'w') as file:
+    with open('codes.csv', 'w', encoding="utf-8") as file:
         for i in st_:
             file.write(i+'\n')
 


### PR DESCRIPTION
The following error was occuring when trying to run script on English Windows 10 (which apparently uses cp1252 encoding by default???) 
Forcing the script to write to .csv in UTF-8 fixed the problem

Traceback (most recent call last):
  File "C:\Users\v1km4\Desktop\comp_networks_ITMO-main\translator.py", line 197, in <module>
    export_to_excel()
  File "C:\Users\v1km4\Desktop\comp_networks_ITMO-main\translator.py", line 194, in export_to_excel
    file.write(i+'\n')
  File "C:\Users\v1km4\AppData\Local\Programs\Python\Python310\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 4-16: character maps to <undefined>